### PR TITLE
add heroku page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Mac
+.DS_Store
+Icon
+._*
+.Spotlight-V100
+
+# SublimeText
+/*.sublime-project
+*.sublime-workspace
+*.sublime-project
+.idea/*
+
+# SASS
+.sass-cache
+
+# Node
+node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > An Open Geospatial ETL Engine
 
-Take geospatial data from one place and transform it into GeoJSON, CSV, KML, a Shapefile, or a Feature Service.
+Leave geospatial data where it lives and transform it into GeoJSON, CSV, KML, a Shapefile, or a Feature Service dynamically.
 
 ```
 ArcGIS Online                   GeoJSON
@@ -18,7 +18,7 @@ OpenStreetMap                   Feature Service
 
 ### Providers
 
-Koop uses **providers** to work with data from different sources -- usually an open data provider serving geospatial data on the web.
+Koop uses **providers** to transform data from different sources -- most often open data providers that serve geospatial data on the web.
 
 | provider | version | build status |
 | -------- | ------- | ------------ |
@@ -64,6 +64,6 @@ Koop has **plugins** that add extra functionality not covered by providers and c
 
 ## Contributions welcome
 
-Koop is entirely open source. Check us out, file an issue, open a pull request, and help grow the project to make it as useful as possible for the geospatial community.
+Koop is entirely open source. Check us out, file an issue, open a pull request, and help grow the project to make it as useful as possible to the geospatial community.
 
 [github.com/koopjs](http://github.com/koopjs)

--- a/docs/heroku.html
+++ b/docs/heroku.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Koop</title>
+  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+
+<main class="page">
+
+<section class="markdown-body">
+<h1>Deploying to Heroku</h1>
+<p>You can deploy an instance of Koop to your <a href="https://www.heroku.com/">Heroku</a> account right away using this button:</p>
+<p><a href="https://heroku.com/deploy?template=https://github.com/koopjs/koop-sample-app"><img src="https://www.herokucdn.com/deploy/button.png" alt="deploy"></a></p>
+<p>If you like doing things manually, feel free to check out out the information in the <a href="https://devcenter.heroku.com/articles/getting-started-with-nodejs#deploy-the-app">Heroku Dev Center</a>.</p>
+<h1>Using PostGIS on Heroku</h1>
+<p>Heroku has beta support for <a href="http://postgis.net/">PostGIS</a>. Read more about it <a href="https://devcenter.heroku.com/articles/heroku-postgres-extensions-postgis-full-text-search#postgis">here</a>.</p>
+<p>Check out <a href="https://github.com/koopjs/koop-pgcache"><code>koop-pgcache</code></a> to find out more about configuring PostGIS as a persistent cache for Koop.</p>
+<nav class="sidebar">
+  <a href="/" class="koop-logo">
+    <img src="/logo.png" alt="Koop">
+  </a>
+  <ul>
+    <li><a class="site-link" href="/docs/setup.html">Setup</a></li>
+    <li><a class="site-link" href="/docs/">Docs</a></li>
+  </ul>
+</nav>
+
+</section>
+</main>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 <blockquote>
 <p>An Open Geospatial ETL Engine</p>
 </blockquote>
-<p>Take geospatial data from one place and transform it into GeoJSON, CSV, KML, a Shapefile, or a Feature Service.</p>
+<p>Leave geospatial data where it lives and transform it into GeoJSON, CSV, KML, a Shapefile, or a Feature Service dynamically.</p>
 <pre><code>ArcGIS Online                   GeoJSON
 Socrata                         CSV
 CKAN             =&gt; Koop =&gt;     KML
@@ -25,7 +25,7 @@ OpenStreetMap                   Feature Service
 <h2>Core Concepts</h2>
 <p><strong>Koop</strong> is, first and foremost, a <strong>server</strong>. It is written in <strong>JavaScript</strong> and runs in the <a href="https://nodejs.org/"><strong>Node.js</strong></a> runtime environment. It acts as <strong>middleware</strong> for the <a href="http://expressjs.com/"><strong>Express</strong></a> web framework. It uses <strong>provider</strong> node modules to <em>extract</em> data from third party providers, <em>transform</em> that data into <a href="http://geojson.org/"><strong>GeoJSON</strong></a> and <em>load</em> it into the <strong>cache</strong>, then serve it on the web in various formats.</p>
 <h3>Providers</h3>
-<p>Koop uses <strong>providers</strong> to work with data from different sources – usually an open data provider serving geospatial data on the web.</p>
+<p>Koop uses <strong>providers</strong> to transform data from different sources – most often open data providers that serve geospatial data on the web.</p>
 <table>
 <thead>
 <tr><th>provider</th><th>version</th><th>build status</th></tr>
@@ -74,7 +74,7 @@ OpenStreetMap                   Feature Service
 </table>
 <p><a href="docs/plugins.html">Read more about plugins</a></p>
 <h2>Contributions welcome</h2>
-<p>Koop is entirely open source. Check us out, file an issue, open a pull request, and help grow the project to make it as useful as possible for the geospatial community.</p>
+<p>Koop is entirely open source. Check us out, file an issue, open a pull request, and help grow the project to make it as useful as possible to the geospatial community.</p>
 <p><a href="http://github.com/koopjs">github.com/koopjs</a></p>
 <nav class="sidebar">
   <a href="/" class="koop-logo">

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,6 +18,9 @@ pages.push({
 }, {
   path: 'docs/setup.html',
   body: md.render(fs.readFileSync('./docs/setup.md', opts))
+}, {
+  path: 'docs/heroku.html',
+  body: md.render(fs.readFileSync('./docs/heroku.md', opts))
 })
 
 pages.forEach(function (page) {


### PR DESCRIPTION
* added .gitignore
* minor copyedits
* added the heroku doc to the build process (just getting familiar with the architecture)

i noticed that i can only get the `.html` files to build is by running `node scripts/build.js` and not by running `npm build` (which looks like it shortcuts the same thing).  anyone else seeing the same?