### PR TITLE
Fix search bar regression

### DIFF
--- a/search.json
+++ b/search.json
@@ -4,7 +4,7 @@
   {% for section in site.data.docs %}
   {% assign section_url = section.path | prepend:"/docs/" %}
   {% assign secs_docs = section.docs.size  %}
-  {% assign forloop = section.docs.size  %}
+  {% assign loop_one = forloop = section.docs.size  %}
     {
       "title": "{{ section.title }}",
       "url": "{{ section.url }}"
@@ -15,8 +15,7 @@
       {
         "title": "{{ item.title }}",
         "url": "{{ item_url }}"
-      }{% unless forloop.last and forloop.last %},{% endunless %}
+      }{% unless loop_one.last and forloop.last %},{% endunless %}
     {% endfor %}
-  
   {% endfor %}
 ]


### PR DESCRIPTION
Fixes a bug in the templating of search.json that was causing an addition of a stray comma, leading to invalid JSON and therefore a broken site search. Fixes https://github.com/koopjs/koopjs.github.io/issues/45.