### PR TITLE
Add "Provider Types" page to "Basics".

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -8,6 +8,8 @@
     path: basics/overview
   - title: Quickstart
     path: basics/quickstart
+  - title: Provider Types
+    path: basics/provider-types
   - title: System Reqiurements
     path: basics/system-requirements
 

--- a/_docs/basics/provider-types.md
+++ b/_docs/basics/provider-types.md
@@ -1,0 +1,45 @@
+---
+title: Provider Types
+permalink: /docs/basics/provider-types
+---
+
+All Koop providers do one essential thing: fetch data from a remote API and convert it to GeoJSON. There are two basic patterns for implemention : *cached*  or *pass-through*. The difference is how much data is fetched from the remote API. Cached providers fetch all dataset records from the remote API. Pass-through providers request only a subset of the data based on a request's query parameters.
+
+Note that a Cached provider is not the same thing as a Koop cache-plugin. A cache-plugin allows data fetched from the remote API to be stored (in memory or Redis) so that similiar requests do not result in repeated fetches to the remote API.  You may still want to use a cache-plugin even if your provider follows the pass-through pattern.
+
+### Cached Providers
+
+As noted above, Cached providers request entire datasets from the remote API. The `getData` function of the provider does not pass on any additional parameters to the remote API that allow it to narrow the dataset.  For example, consider this request to the [Craigslist provider](https://github.com/dmfenton/koop-provider-craigslist):
+
+```
+http://localhost:8080/craigslist/houston/apartments/FeatureServer/0/query?where=price<=1000
+```
+
+The Craigslist provider handles this request by fetching *all* the apartment records for Houston, regardless of price.  It then passes the full dataset on to Koop which uses Winnow to filter the records down to only those with `price < 1000`. This pattern is termed "cached" because the full dataset is cached in memory for Winnow to operate on.
+
+It makes sense to use a cache-provider strategy if at least one of the following is true:
+
+- The remote dataset is very small
+- The entire remote dataset can be fetched
+- The remote API does not support filters or geographic queries
+- The remote API is slow to respond
+
+### Pass-Through
+
+Pass-through providers act as a proxy/translator between the client and the remote API.  More specifically, they convert GeoServices API query parameters to the analogous query parameters on the remote API. As a result, pass-through providers only fetch a targeted subset of the remote dataset. As an example, consider this request to the [Google Analytics provider](https://github.com/koopjs/koop-provider-google-analytics):
+
+```
+http://localhost:8080/metrics/sessions::views/eventCategory/FeatureServer/0/query?where=country='United States'
+```
+
+The Google Analytics provider handles this request by converting the GeoServices API `where` parameter to the Google Analytics API equivalent. It then fetches *only* the subset of data with `country` equal to 'United States'. This partial dataset is then passed on to Koop and then back to the client.  (Pro tip: Koop/Winnow will attempt to apply the `where` filter to the partial dataset a second time unless you flag the dataset as already having the `where` applied).
+
+It's important to note that the pass-through pattern can be partially applied, i.e., you don't have to provide a translation for every GeoService API query parameter.  For example, you might author a translation for the `where` parameter, but not the `time` or `geometry` parameters.  Partial support for query parameters is still useful, because it reduces the size of the dataset the Koop/Winnow has to loop through to apply other filters or sorts.
+
+It makes sense to use a pass-through strategy if at least one of the following is true:
+
+- The remote dataset is too large to be fetched as a whole
+- The remote API does not allow fetching the entire dataset
+- The remote API supports filters and geographic queries
+- The remote API is quick to respond
+

--- a/_docs/usage/provider.md
+++ b/_docs/usage/provider.md
@@ -6,9 +6,9 @@ permalink: /docs/usage/provider
 #### Contents
 1. [The `index.js` file](#indexjs)  
 2. [The `model.js` file](#modeljs)  
-3. [Cached vs. Pass-through providers](#cached-vs.-pass-through)  
-4. [Routes and Controllers](#routes-and-controllers)
+3. [Routes and Controllers](#routes-and-controllers)  
 
+Note: the discussion of Cached vs Pass-through providers has moved [here](../basics/provider-types).
 <hr>
 
 ## index.js
@@ -167,50 +167,6 @@ Model.prototype.createKey = function (req) {
   return key
 }
 ```
-
-_[back to top](#contents)_
-
-## Cached vs. Pass-Through Providers
-
-Providers typically fall into two categories: cached and pass-through.
-
-### Cached
-
-Cached providers periodically request entire datasets from the remote API.
-
-[Koop-Provider-Craigslist](https://github.com/dmfenton/koop-provider-craigslist) is a good example. The Craigslist API returns the entire set of postings for a given city and type in one call (e.g. Atlanta apartments). The data also does not change that frequently. Therefore the Craigslist provider uses the Koop cache with a TTL of 1 hour, guaranteeing that data will never be more than an hour out of date.
-
-It makes sense to use a cache strategy if at least one of the following is true:
-- The remote dataset does not change often
-- The remote dataset is large
-- The entire remote dataset can be fetched
-- The remote API does not support filters or geographic queries
-- The remote API is slow to respond
-
-### Pass-Through
-
-Pass-through providers do not store any data, they act as a proxy/translator between the client and the remote API.
-
-[Koop-Provider-Yelp](https://github.com/koopjs/Koop-Provider-Yelp) is a good example. The Yelp API supports filters and geographic queries, but it only returns 20 results at a time and there is no way to download the entire Yelp dataset.
-
-It makes sense to use a pass-through strategy if at least one of the following is true:
-- The remote dataset changes frequently
-- The remote dataset is very small
-- The remote dataset is too large to be fetched as a whole
-- The remote API does not allow fetching the entire dataset
-- The remote API supports filters and geographic queries
-- The remote API is quick to respond
-
-The request below fetches data from yelp and translates it into Geoservices JSON
-
-```
-http://localhost:8080/yelp/FeatureServer/0?where=term=pizza
-```
-GeoJSON can be retrieved as well
-```
-http://localhost:8080/yelp/FeatureServer/0?where=term=pizza&f=geojson
-```
-
 _[back to top](#contents)_
 
 ## Routes and Controllers

--- a/css/main.scss
+++ b/css/main.scss
@@ -29,6 +29,7 @@ html {
 body {
   padding-top: $navbar-height + $navbar-margin-bottom;
   margin-bottom: 46px;
+  line-height: 2em;
 }
 
 h1, .h1, h2, .h2, h3, .h3, h4, .h4, h5, .h5, h6, .h6 {
@@ -126,6 +127,8 @@ h1:hover, .h1:hover, h2:hover, .h2:hover, h3:hover, .h3:hover, h4:hover, .h4:hov
 }
 
 .panel {
+  line-height: 1.4em;
+
   .list-group  {
 
     padding-bottom: 6px;


### PR DESCRIPTION
This PR adds a "Provider Types" page to the "Basics" section of the docs.  It expands, updates and clarifies the content that was formerly in the "Cached vs Pass-through Providers" section of the provider spec.

Also added a minor css change affecting line-height.