### PR TITLE
Split provider specification into separate pages

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -8,14 +8,10 @@
     path: basics/overview
   - title: Quick start
     path: basics/quickstart
-  - title: Usage Basics
-    path: basics/usage-basics
   - title: Provider Types
     path: basics/provider-types
   - title: System Reqiurements
     path: basics/system-requirements
-  - title: FAQs
-    path: basics/faqs
 
 - title: Available Plugins
   path: available-plugins/providers

--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -8,10 +8,14 @@
     path: basics/overview
   - title: Quick start
     path: basics/quickstart
+  - title: Usage Basics
+    path: basics/usage-basics
   - title: Provider Types
     path: basics/provider-types
   - title: System Reqiurements
     path: basics/system-requirements
+  - title: FAQs
+    path: basics/faqs
 
 - title: Available Plugins
   path: available-plugins/providers
@@ -49,7 +53,12 @@
   - title: Plugin Registration Spec
     path: development/registration
   - title: Provider Spec
-    path: development/provider
+    path: development/provider/registration
+    subdocs:
+    - title: Registration file and options
+      path: development/provider/registration
+    - title: Model Class
+      path: development/provider/model
   - title: Cache Spec
     path: development/cache
   - title: Output Spec

--- a/_docs/development/provider/model.md
+++ b/_docs/development/provider/model.md
@@ -13,6 +13,9 @@ Model.prototype.getData(req, callback) {
     // if the http request fails, return and callback with error
     if (err) return callback(err)
 
+    // Set metadata used by Koop; geometryType is required unless your data is not geospatial
+    geojson.metadata = { geometryType: 'Point' }
+
     callback(null, geojson)
   })
 }

--- a/_docs/development/provider/registration.md
+++ b/_docs/development/provider/registration.md
@@ -1,0 +1,59 @@
+---
+title: Provider Specification - registration object
+permalink: /docs/development/provider/registration
+redirect_from: /docs/development/index.html
+---
+
+Every provider must have a file called `index.js` that exports an object literal. Its purpose is to tell Koop how to load and use the provider. Below is an example for the Koop 3.x specification:
+
+```js
+module.exports = {
+  name: 'new-provider-name',
+  type: 'provider',
+  version: require('<path-to-package.json>').version,
+  Model: require('<path-to-model-class-module>'),
+  hosts: true,
+  disableIdParam: false,
+  routes: require('<path-to-routes-array-module>'),
+  Controller: require('<path-to-controller-module>'),
+}
+```
+
+The table below  describes the keys in more detail:
+
+| Key | Required? | Type | Description |
+| :--- | :--- | :--- | :--- |
+| type | Yes | `string` | Identifies the plugin type; should have value `'provider'`
+| name | Yes | `string` | A URL safe string that identifies the provider; used as part of the routes to provider data |
+| version | Yes | `string` | version number of the provider|
+| Model | Yes | `class` | The Model class or `require` for the Model class module |
+| hosts | No | `Boolean` | Adds a `:host` parameter in routes|
+| disableIdParams | No | `Boolean` | Removes the default `:id` parameter from routes|
+| routes | No | `object[]` | An array of route objects that expose routes specific to this provider |
+| Controller | No | `class` | The Controller class that supports handling for provider routes |
+
+
+As an alternative to exporting an object literal, you can instead have `index.js` export an initialization function that returns the registration object. This is useful if you need to dynamically set registration properties:
+
+```js
+module.exports = function(options = {}) {
+  // Allow name to be set by options
+  const name = options.name ? options.name : 'example-provider'
+
+  return {
+    type: 'provider',
+    name,
+    hosts: true
+    disableIdParam: false
+    Model: require('./model'),
+    version: require('../package.json').version
+  }
+}
+```
+
+Note that you would need to execute the above initialization function during registration:
+
+```js
+const provider = require('<npm-or-path-to-provider>')({ name: 'my-provider' })
+koop.register(provider)
+```


### PR DESCRIPTION
The provider specification is very long.  The PR provides a subsection for the provider docs and splits the existing doc across two pages; one describes the `index.js` file, the other describes the model.js file.  Future PRs may split the model.js description into addition pages as well.