### PR TITLE
Announce monorepo

### DIFF
--- a/_docs/usage/authorization.md
+++ b/_docs/usage/authorization.md
@@ -19,7 +19,7 @@ Usage of an authorization-plugin can be conceptually divided into three parts: (
 
 ```js
 // Initialize Koop
-const Koop = require('koop')
+const Koop = require('@koopjs/koop-core')
 const koop = new Koop()
 
 // Koop has already added koop-output-geoservices (i.e. FeatureServer routes) by default

--- a/_docs/usage/cache.md
+++ b/_docs/usage/cache.md
@@ -12,7 +12,7 @@ A Koop cache plugin stores data requested from the provider for use in followup 
 To be used by Koop, the cache must be registered with the Koop object before the server begins listening as in the example below.
 
 ```js
-const Koop = require('koop')
+const Koop = require('@koopjs/koop-core')
 const koop = new Koop()
 const cache = require('koop-cache-redis')
 koop.register(cache)

--- a/_docs/usage/koop-core.md
+++ b/_docs/usage/koop-core.md
@@ -28,7 +28,7 @@ Create a new file named `server.js`.  The typical content of the Koop server fil
 ```js
 
 // Initialize Koop
-const Koop = require('koop')
+const Koop = require('@koopjs/koop-core')
 const koop = new Koop()
 
 /* Optional - register additional output-services */

--- a/_docs/usage/output.md
+++ b/_docs/usage/output.md
@@ -10,7 +10,7 @@ By default, Koop registers the [Geoservices output-plugin](https://github.com/ko
 To be used by Koop, the output-plugin must be registered with the Koop instance before the it begins listening.
 
 ```js
-const Koop = require('koop')
+const Koop = require('@koopjs/koop-core')
 const koop = new Koop()
 const output = require('<output-plugin-package-or-path>')
 koop.register(output)

--- a/_docs/usage/provider.md
+++ b/_docs/usage/provider.md
@@ -7,7 +7,7 @@ In your Koop server file, the provider must be registered with the Koop instance
 
 <div class='codeanchor' id="figure-1"></div>
 ```js
-const Koop = require('koop')
+const Koop = require('@koopjs/koop-core')
 const koop = new Koop()
 const provider = require('<provider-npm-package or local-path>')
 koop.register(provider, { /* provider options */ })

--- a/_posts/2022-12-12-koop-monorepo.md
+++ b/_posts/2022-12-12-koop-monorepo.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title:  "New Koop Monorepo"
+date:   2022-12-12
+author: Rich Gwozdz
+---
+
+We have migrated Koop and it's core dependencies to a monorepo at [https://github.com/koopjs/koop](https://github.com/koopjs/koop). The monorepo includes the following packages:
+- koop-core (the main koop module)
+- output-geoservices
+- featureserver
+- winnow
+- koop-logger
+- cache-memory
+
+This move will ease development, testing, and publishing. The diagram below illustrates the dependency relationships between the monorepo packages:
+![Screen Shot 2022-11-30 at 1 03 46 PM](https://user-images.githubusercontent.com/4369192/204908289-82659cfe-fcf3-404a-aa70-79baf540f1b8.png)
+
+
+## Migrating
+It's important to note that the latest Koop has been published under the `@koopjs` NPM organization. You will need to update your koop applications by:
+
+```bash
+> npm uninstall koop
+
+> npm install @koopjs/koop-core
+
+```
+Then replace any imports in your code-base.  For example:
+
+```diff
+- const Koop = require('koop')
++ const Koop = require('@koopjs/koop-core')
+```
+
+FeatureServer and Winnow have also moved to the `@koopjs` NPM organization. If you happen to be using those repositories outside of Koop you'll need to update to `@koopjs/featureserver` and `@koopjs/winnow`. Note that the older repositories have been marked as deprecated and have no explicit maintenance plan.
+
+## Contributing
+The new monorepo includes tooling to help standardize contributions and make semantic releases to NPM. This includes the requirement of (1) conventional commit messages, (2) code coverage, and (3) semantice release control with [changesets](https://github.com/changesets/changesets). Take a look at the [contribution guidelines](https://github.com/koopjs/koop/blob/master/README.md#contributing) for more information.
+


### PR DESCRIPTION
- add blog post about monorepo
- change some reference so they point to `@koopjs/koop-core`