### PR TITLE
Fix typo on "Reqiurements" in the docs menu

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -12,7 +12,7 @@
     path: basics/provider-types
   - title: FAQs
     path: basics/faqs
-  - title: System Reqiurements
+  - title: System Requirements
     path: basics/system-requirements
 
 - title: Available Plugins


### PR DESCRIPTION
Just a little typo fix on the sidebar menu in the docs. 